### PR TITLE
Fixed issue #7 where code generator produced code that leaked memory

### DIFF
--- a/src/compiler/objc_primitive_field.cc
+++ b/src/compiler/objc_primitive_field.cc
@@ -512,7 +512,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     printer->Print(variables_,
       "if (other.$list_name$.count > 0) {\n"
       "  if (result.$list_name$ == nil) {\n"
-      "    result.$list_name$ = [other.$list_name$ copyWithZone:[other.$list_name$ zone]];\n"
+      "    result.$list_name$ = [[other.$list_name$ copyWithZone:[other.$list_name$ zone]] autorelease];\n"
       "  } else {\n"
       "    [result.$list_name$ appendArray:other.$list_name$];\n"
       "  }\n"


### PR DESCRIPTION
objc_primitive_field.cc generates code that leaks
copied objects. See https://github.com/booyah/protobuf-objc/issues/7
