### PR TITLE
update project to 4.2 (staying 3.2 compatible)

### DIFF
--- a/src/runtime/ProtocolBuffers.xcodeproj/project.pbxproj
+++ b/src/runtime/ProtocolBuffers.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -505,8 +505,11 @@
 /* Begin PBXProject section */
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0420;
+			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "ProtocolBuffers" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -626,7 +629,6 @@
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/ProtocolBuffers.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -669,10 +671,9 @@
 				HEADER_SEARCH_PATHS = ../ProtocolBuffers;
 				OBJROOT = Build;
 				OTHER_LDFLAGS = "-ObjC";
-				PREBINDING = NO;
 				PRIVATE_HEADERS_FOLDER_PATH = ../ProtocolBuffers/private;
 				PUBLIC_HEADERS_FOLDER_PATH = ../ProtocolBuffers;
-				SDKROOT = iphoneos4.1;
+				SDKROOT = iphoneos;
 				SYMROOT = Build/Products;
 			};
 			name = Debug;
@@ -687,10 +688,9 @@
 				HEADER_SEARCH_PATHS = ../ProtocolBuffers;
 				OBJROOT = Build;
 				OTHER_LDFLAGS = "-ObjC";
-				PREBINDING = NO;
 				PRIVATE_HEADERS_FOLDER_PATH = ../ProtocolBuffers/private;
 				PUBLIC_HEADERS_FOLDER_PATH = ../ProtocolBuffers;
-				SDKROOT = iphoneos4.1;
+				SDKROOT = iphoneos;
 				SYMROOT = Build/Products;
 			};
 			name = Release;
@@ -703,7 +703,6 @@
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -718,7 +717,6 @@
 					SenTestingKit,
 					"-all_load",
 				);
-				PREBINDING = NO;
 				PRODUCT_NAME = UnitTests;
 				SDKROOT = "";
 				VALID_ARCHS = "i386 x86_64";
@@ -734,7 +732,6 @@
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -748,7 +745,6 @@
 					SenTestingKit,
 					"-all_load",
 				);
-				PREBINDING = NO;
 				PRODUCT_NAME = UnitTests;
 				SDKROOT = "";
 				VALID_ARCHS = "i386 x86_64";


### PR DESCRIPTION
This does the cleanup that 4.2 requests (gets rid of PREBINDING, sets iOS SDK to latest and removes GCC_ENABLE_FIX_AND_CONTINUE.
