### PR TITLE
Fix for a comparison bug in enums in generated code

### DIFF
--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -215,7 +215,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void EnumFieldGenerator::GenerateIsEqualCodeSource(io::Printer* printer) const {
     printer->Print(variables_,
       "self.has$capitalized_name$ == otherMessage.has$capitalized_name$ &&\n"
-      "(!self.has$capitalized_name$ || self.$name$ != otherMessage.$name$) &&");
+      "(!self.has$capitalized_name$ || self.$name$ == otherMessage.$name$) &&");
   }
 
 


### PR DESCRIPTION
The code fixes a bug that causes incorrect isEqual results when the object includes enums.
