### PR TITLE
avoid "local ... hides instance variable" warnings in generated code

### DIFF
--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -100,8 +100,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       "- (BOOL) has$capitalized_name$ {\n"
       "  return !!has$capitalized_name$_;\n"
       "}\n"
-      "- (void) setHas$capitalized_name$:(BOOL) value {\n"
-      "  has$capitalized_name$_ = !!value;\n"
+      "- (void) setHas$capitalized_name$:(BOOL) value_ {\n"
+      "  has$capitalized_name$_ = !!value_;\n"
       "}\n"
       "@synthesize $name$;\n");
   }
@@ -199,7 +199,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void EnumFieldGenerator::GenerateSerializedSizeCodeSource(io::Printer* printer) const {
     printer->Print(variables_,
       "if (self.has$capitalized_name$) {\n"
-      "  size += computeEnumSize($number$, self.$name$);\n"
+      "  size_ += computeEnumSize($number$, self.$name$);\n"
       "}\n");
   }
 
@@ -436,17 +436,17 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       "}\n");
 
     printer->Print(
-      "size += dataSize;\n");
+      "size_ += dataSize;\n");
 
     if (descriptor_->options().packed()) {
       printer->Print(variables_,
         "if (count > 0) {\n"
-        "  size += $tag_size$;\n"
-        "  size += computeRawVarint32Size(dataSize);\n"
+        "  size_ += $tag_size$;\n"
+        "  size_ += computeRawVarint32Size(dataSize);\n"
         "}\n");
     } else {
       printer->Print(variables_,
-        "size += $tag_size$ * count;\n");
+        "size_ += $tag_size$ * count;\n");
     }
 
     if (descriptor_->options().packed()) {

--- a/src/compiler/objc_message.cc
+++ b/src/compiler/objc_message.cc
@@ -584,12 +584,12 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     printer->Print(
       "}\n"
       "- (int32_t) serializedSize {\n"
-      "  int32_t size = memoizedSerializedSize;\n"
-      "  if (size != -1) {\n"
-      "    return size;\n"
+      "  int32_t size_ = memoizedSerializedSize;\n"
+      "  if (size_ != -1) {\n"
+      "    return size_;\n"
       "  }\n"
       "\n"
-      "  size = 0;\n");
+      "  size_ = 0;\n");
     printer->Indent();
 
     for (int i = 0; i < descriptor_->field_count(); i++) {
@@ -598,21 +598,21 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 
     if (descriptor_->extension_range_count() > 0) {
       printer->Print(
-        "size += [self extensionsSerializedSize];\n");
+        "size_ += [self extensionsSerializedSize];\n");
     }
 
     if (descriptor_->options().message_set_wire_format()) {
       printer->Print(
-        "size += self.unknownFields.serializedSizeAsMessageSet;\n");
+        "size_ += self.unknownFields.serializedSizeAsMessageSet;\n");
     } else {
       printer->Print(
-        "size += self.unknownFields.serializedSize;\n");
+        "size_ += self.unknownFields.serializedSize;\n");
     }
 
     printer->Outdent();
     printer->Print(
-      "  memoizedSerializedSize = size;\n"
-      "  return size;\n"
+      "  memoizedSerializedSize = size_;\n"
+      "  return size_;\n"
       "}\n");
   }
 

--- a/src/compiler/objc_message_field.cc
+++ b/src/compiler/objc_message_field.cc
@@ -101,8 +101,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       "- (BOOL) has$capitalized_name$ {\n"
       "  return !!has$capitalized_name$_;\n"
       "}\n"
-      "- (void) setHas$capitalized_name$:(BOOL) value {\n"
-      "  has$capitalized_name$_ = !!value;\n"
+      "- (void) setHas$capitalized_name$:(BOOL) value_ {\n"
+      "  has$capitalized_name$_ = !!value_;\n"
       "}\n"
       "@synthesize $name$;\n");
   }
@@ -226,7 +226,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void MessageFieldGenerator::GenerateSerializedSizeCodeSource(io::Printer* printer) const {
     printer->Print(variables_,
       "if (self.has$capitalized_name$) {\n"
-      "  size += compute$group_or_message$Size($number$, self.$name$);\n"
+      "  size_ += compute$group_or_message$Size($number$, self.$name$);\n"
       "}\n");
   }
 
@@ -433,7 +433,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void RepeatedMessageFieldGenerator::GenerateSerializedSizeCodeSource(io::Printer* printer) const {
     printer->Print(variables_,
       "for ($type$ *element in self.$list_name$) {\n"
-      "  size += compute$group_or_message$Size($number$, element);\n"
+      "  size_ += compute$group_or_message$Size($number$, element);\n"
       "}\n");
   }
 

--- a/src/compiler/objc_primitive_field.cc
+++ b/src/compiler/objc_primitive_field.cc
@@ -269,8 +269,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       "- (BOOL) has$capitalized_name$ {\n"
       "  return !!has$capitalized_name$_;\n"
       "}\n"
-      "- (void) setHas$capitalized_name$:(BOOL) value {\n"
-      "  has$capitalized_name$_ = !!value;\n"
+      "- (void) setHas$capitalized_name$:(BOOL) value_ {\n"
+      "  has$capitalized_name$_ = !!value_;\n"
       "}\n");
 
     if (GetObjectiveCType(descriptor_) == OBJECTIVECTYPE_BOOLEAN) {
@@ -278,8 +278,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
         "- (BOOL) $name$ {\n"
         "  return !!$name$_;\n"
         "}\n"
-        "- (void) set$capitalized_name$:(BOOL) value {\n"
-        "  $name$_ = !!value;\n"
+        "- (void) set$capitalized_name$:(BOOL) value_ {\n"
+        "  $name$_ = !!value_;\n"
         "}\n");
     } else {
       printer->Print(variables_, "@synthesize $name$;\n");
@@ -384,7 +384,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void PrimitiveFieldGenerator::GenerateSerializedSizeCodeSource(io::Printer* printer) const {
     printer->Print(variables_,
       "if (self.has$capitalized_name$) {\n"
-      "  size += compute$capitalized_type$Size($number$, self.$name$);\n"
+      "  size_ += compute$capitalized_type$Size($number$, self.$name$);\n"
       "}\n");
   }
 
@@ -627,18 +627,18 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
         "dataSize = $fixed_size$ * count;\n");
     }
 
-    printer->Print("size += dataSize;\n");
+    printer->Print("size_ += dataSize;\n");
 
     if (descriptor_->options().packed()) {
       printer->Print(variables_,
         "if (count > 0) {\n"
-        "  size += $tag_size$;\n"
-        "  size += computeInt32SizeNoTag(dataSize);\n"
+        "  size_ += $tag_size$;\n"
+        "  size_ += computeInt32SizeNoTag(dataSize);\n"
         "}\n"
         "$name$MemoizedSerializedSize = dataSize;\n");
     } else {
       printer->Print(variables_,
-        "size += $tag_size$ * count;\n");
+        "size_ += $tag_size$ * count;\n");
     }
 
     printer->Outdent();


### PR DESCRIPTION
GCC gets upset if you hide an instance variable with a local variable
and issues a warning that apparently can't be turned off.  This commit
renames the "size" local variable in the serializedSize generated
method so it doesn't hide the instance variable.  It also renames the
"value" parameter to the setHasFoo: methods to avoid hiding a field
named "value" if it happens to exist.
