### PR TITLE
CodedOutputStream.h declares writeRawLittleEndian32: and writeRawLittleE...

### DIFF
--- a/src/runtime/Classes/CodedOutputStream.h
+++ b/src/runtime/Classes/CodedOutputStream.h
@@ -68,9 +68,6 @@
 /** Encode and write a varint. */
 - (void) writeRawVarint64:(int64_t) value;
 
-- (void) writeRawLittleEndian32:(int32_t) value;
-- (void) writeRawLittleEndian64:(int64_t) value;
-
 /** Write an array of bytes. */
 - (void) writeRawData:(const NSData*) data;
 - (void) writeRawData:(const NSData*) data offset:(int32_t) offset length:(int32_t) length;


### PR DESCRIPTION
CodedOutputStream.h declares writeRawLittleEndian32: and writeRawLittleEndian64: twice (causing a compiler warning)

The file contains:

/*\* Write a little-endian 32-bit integer. */

(void) writeRawLittleEndian32:(int32_t) value; /*\* Write a little-endian 64-bit integer. */
(void) writeRawLittleEndian64:(int64_t) value;
and then a bit further down:

(void) writeRawLittleEndian32:(int32_t) value;
(void) writeRawLittleEndian64:(int64_t) value;
This causes compiler warnings.
